### PR TITLE
Get img tags when looking for pngs

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: node index.js
+debug: node-debug index.js


### PR DESCRIPTION
We were only crawling imageSets. Now we're also extracting the `src` attributes from `<img>` tags, discarding those that are `.jpe?g`s or `.gif`s
