### PR TITLE
Upgrade dependencies to remove vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "cheerio": "^0.19.0",
     "cors": "^2.7.1",
     "dotenv": "^1.2.0",
-    "express": "^4.13.1",
+    "express": "^4.15.5",
     "form-data": "^0.2.0",
     "jsdom": "^0.3.4",
     "moment": "^2.10.3",
@@ -38,7 +38,7 @@
     "@financial-times/secret-squirrel": "^2.5.10",
     "chai": "^3.2.0",
     "husky": "^0.14.3",
-    "mocha": "^2.2.5",
+    "mocha": "^4.0.1",
     "sinon": "^1.17.7",
     "superagent-mock": "^1.10.0"
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "pg-bluebird": "^1.0.8",
     "q": "^1.4.1",
     "slack-node": "^0.1.3",
-    "superagent": "^1.2.0",
+    "superagent": "^3.6.3",
     "superagent-promise-plugin": "^3.2.0",
     "underscore": "^1.8.3",
     "uuid": "^2.0.1",
@@ -40,6 +40,6 @@
     "husky": "^0.14.3",
     "mocha": "^4.0.1",
     "sinon": "^1.17.7",
-    "superagent-mock": "^1.10.0"
+    "superagent-mock": "^3.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": "~6.11.x"
   },
   "scripts": {
-    "test": "mocha",
+    "test": "mocha --timeout 15000",
     "precommit": "node_modules/.bin/secret-squirrel",
     "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg"
   },


### PR DESCRIPTION
 🐿 v2.5.16

Vulnerable libraries according to the cyber security team:
- minimatch.js
- Growl.js

Verify that both vulnerabilities have been removed with snyk - https://www.npmjs.com/package/snyk

NOTE - According to snyk, there are more vulnerabilities we may need to attend to